### PR TITLE
Adds multi-platform support for Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM maven:3.9.11-eclipse-temurin-17-noble AS base
+FROM --platform=${BUILDPLATFORM} maven:3.9.11-eclipse-temurin-17-noble AS base
 
 # renovate: datasource=github-releases depName=magefree/mage
 ARG UPSTREAM_VERSION=xmage_1.4.57V2
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.m2 mvn clean install -DskipTests
 WORKDIR /opt/xmage/Mage.Server
 RUN --mount=type=cache,target=/root/.m2 mvn package assembly:single
 
-FROM eclipse-temurin:8u462-b08-jre-noble AS jre
+FROM --platform=${BUILDPLATFORM} eclipse-temurin:8u462-b08-jre-noble AS jre
 
 FROM jre AS extract
 RUN DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Configures CI workflow to build multi-platform Docker images,
enabling 'amd64' and 'arm64' builds except for pull requests.
Updates Dockerfile to use BUILDPLATFORM variable for base images,
ensuring adaptability across different architectures.
